### PR TITLE
Use Cadence 1.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "main":             "arguable",
     "dependencies":
     {
-                        "cadence":  "1.0.0",
+                        "cadence":  "1.0.x",
                         "interrupt": "0.0.10",
                         "synonymous": "0.0.8"
     },


### PR DESCRIPTION
There might be a reason for specifying Cadence 1.0.0, but I believe this makes use of the new Cadence semver more effectively